### PR TITLE
cache: store logs for 7 days. store reports for 5 minutes.

### DIFF
--- a/src/cache.py
+++ b/src/cache.py
@@ -30,5 +30,5 @@ class Cache():
     def get_key_count(self):
         return len(self.get_all_keys())
 
-    def __call__(self, ttl=60 * 60 * 24, limit=500, namespace=None):
+    def __call__(self, ttl=60 * 60 * 24 * 7, limit=5000, namespace=None):
         return self.__cache.cache(ttl, limit, namespace)

--- a/src/client.py
+++ b/src/client.py
@@ -90,7 +90,7 @@ class WCLClient():
                 f"Reports for {guild}-{server}-{region} already exists, fetching from cache."
             )
 
-        @self.__cache()
+        @self.__cache(ttl = 60 * 5)
         def _get_reports(
             guild: str,
             server: str,


### PR DESCRIPTION
Increase limit of cached keys to 5k, which is about 625Mb.
Reports are only stored for 5 minutes due to them needing to be refreshed if new data is uploaded to WCL.